### PR TITLE
Use public packages from nuget.org

### DIFF
--- a/ContosoOnline/OrderProcessor/OrderProcessor.csproj
+++ b/ContosoOnline/OrderProcessor/OrderProcessor.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="Grpc.AspNetCore" Version="2.49.0" />
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0-alpha.1.23269.5" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0-preview.4.23273.7" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
     </ItemGroup>
 

--- a/ContosoOnline/Orders/Orders.csproj
+++ b/ContosoOnline/Orders/Orders.csproj
@@ -11,7 +11,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Resilience" Version="8.0.0-alpha.1.23269.5" />
+        <PackageReference Include="Microsoft.Extensions.Resilience" Version="8.0.0-preview.4.23273.7" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
         <PackageReference Include="Nanorm.Npgsql" Version="0.0.4" />
         <PackageReference Include="Npgsql" Version="8.0.0-preview.3" />

--- a/ContosoOnline/Store/Store.csproj
+++ b/ContosoOnline/Store/Store.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0-alpha.1.23269.5" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0-preview.4.23273.7" />
         <PackageReference Include="Grpc.AspNetCore" Version="2.49.0" />
         <PackageReference Include="MudBlazor" Version="6.2.3" />
     </ItemGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Switching dependencies to the (now) public versions of those packages in NuGet.org and removing the now unnecessary package feed. I did validate that running the application using docker compose works as expected, and that the script of the demo (including switching off the orders service) still works as expected.