### PR TITLE
Parameterise Prometheus data source in the dashboard

### DIFF
--- a/grafana/dashboards/aspnetcore-dashboard.json
+++ b/grafana/dashboards/aspnetcore-dashboard.json
@@ -32,7 +32,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "Prometheus"
+        "uid": "${prometheus_source}"
       },
       "fieldConfig": {
         "defaults": {
@@ -138,7 +138,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.50, sum(rate(http_server_duration_ms_bucket{job=\"$job\", instance=\"$instance\"}[$__rate_interval])) by (le))",
@@ -149,7 +149,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.75, sum(rate(http_server_duration_ms_bucket{job=\"$job\", instance=\"$instance\"}[$__rate_interval])) by (le))",
@@ -161,7 +161,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.90, sum(rate(http_server_duration_ms_bucket{job=\"$job\", instance=\"$instance\"}[$__rate_interval])) by (le))",
@@ -173,7 +173,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.95, sum(rate(http_server_duration_ms_bucket{job=\"$job\", instance=\"$instance\"}[$__rate_interval])) by (le))",
@@ -185,7 +185,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.98, sum(rate(http_server_duration_ms_bucket{job=\"$job\", instance=\"$instance\"}[$__rate_interval])) by (le))",
@@ -197,7 +197,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum(rate(http_server_duration_ms_bucket{job=\"$job\", instance=\"$instance\"}[$__rate_interval])) by (le))",
@@ -209,7 +209,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.999, sum(rate(http_server_duration_ms_bucket{job=\"$job\", instance=\"$instance\"}[$__rate_interval])) by (le))",
@@ -225,7 +225,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "Prometheus"
+        "uid": "${prometheus_source}"
       },
       "fieldConfig": {
         "defaults": {
@@ -350,7 +350,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "sum(rate(http_server_duration_ms_count{job=\"$job\", instance=\"$instance\", http_status_code=~\"4..|5..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_duration_ms_count{job=\"$job\", instance=\"$instance\"}[$__rate_interval]))",
@@ -361,7 +361,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "sum(rate(http_server_duration_ms_count{job=\"$job\", instance=\"$instance\", http_status_code=~\"4..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_duration_ms_count{job=\"$job\", instance=\"$instance\"}[$__rate_interval]))",
@@ -373,7 +373,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "sum(rate(http_server_duration_ms_count{job=\"$job\", instance=\"$instance\", http_status_code=~\"5..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_duration_ms_count{job=\"$job\", instance=\"$instance\"}[$__rate_interval]))",
@@ -389,7 +389,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "Prometheus"
+        "uid": "${prometheus_source}"
       },
       "description": "",
       "fieldConfig": {
@@ -467,7 +467,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "sum(ec_Microsoft_AspNetCore_Server_Kestrel_current_connections{job=\"$job\", instance=\"$instance\"})",
@@ -482,7 +482,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "Prometheus"
+        "uid": "${prometheus_source}"
       },
       "description": "",
       "fieldConfig": {
@@ -560,7 +560,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "sum(ec_System_Net_Http_current_requests{job=\"$job\", instance=\"$instance\"})",
@@ -575,7 +575,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "Prometheus"
+        "uid": "${prometheus_source}"
       },
       "description": "",
       "fieldConfig": {
@@ -627,7 +627,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "sum by (scheme) (\r\n    max_over_time(http_server_duration_ms_count{job=\"$job\", instance=\"$instance\"}[$__rate_interval])\r\n  )",
@@ -642,7 +642,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "Prometheus"
+        "uid": "${prometheus_source}"
       },
       "description": "",
       "fieldConfig": {
@@ -694,7 +694,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "expr": "sum by (protocol) (\r\n    max_over_time(http_server_duration_ms_count{job=\"$job\", instance=\"$instance\"}[$__rate_interval])\r\n  )",
@@ -709,7 +709,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "Prometheus"
+        "uid": "${prometheus_source}"
       },
       "description": "",
       "fieldConfig": {
@@ -840,7 +840,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${prometheus_source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -901,7 +901,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "Prometheus"
+          "uid": "${prometheus_source}"
         },
         "definition": "label_values(ec_System_Net_Http_current_requests, job)",
         "hide": 0,
@@ -928,7 +928,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "Prometheus"
+          "uid": "${prometheus_source}"
         },
         "definition": "label_values(ec_System_Net_Http_current_requests{job=~\"$job\"}, instance)",
         "hide": 0,
@@ -946,6 +946,25 @@
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": "The Prometheus data source",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "prometheus_source",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
       }
     ]
   },

--- a/grafana/dashboards/aspnetcore-dashboard.json
+++ b/grafana/dashboards/aspnetcore-dashboard.json
@@ -264,6 +264,8 @@
             }
           },
           "mappings": [],
+          "max": 1,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [


### PR DESCRIPTION
I imported the dashboard into one of our hosted Grafana instances and trying to fix all the data sources to see what new metrics were coming out of an app where we're testing out the new metrics in preview 4 wasn't the most fun experience.

This PR adds a parameter for the Prometheus data source so you only need to change it in once place if importing it elsewhere.
