### PR TITLE
Moved port for Orders from 5000 to 5004 for Mac

### DIFF
--- a/ContosoOnline/OrderProcessor/appsettings.json
+++ b/ContosoOnline/OrderProcessor/appsettings.json
@@ -7,7 +7,7 @@
     }
   },
   "PRODUCTS_URL": "http://localhost:5002",
-  "ORDERS_URL": "http://localhost:5000",
+  "ORDERS_URL": "http://localhost:5004",
   "HttpStandardResilienceOptions": {
     "BulkheadOptions": {
       "MaxConcurrency": 1000,

--- a/ContosoOnline/Orders/Properties/launchSettings.json
+++ b/ContosoOnline/Orders/Properties/launchSettings.json
@@ -8,7 +8,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "http://localhost:5004"
     }
   }
 }

--- a/ContosoOnline/Proxy/appsettings.json
+++ b/ContosoOnline/Proxy/appsettings.json
@@ -7,7 +7,7 @@
       "Yarp": "Warning"
     }
   },
-  "ORDERS_API": "http://localhost:5000",
+  "ORDERS_API": "http://localhost:5004",
   "STORE_UI": "http://localhost:5176",
   "ReverseProxy": {
     "Clusters": {

--- a/ContosoOnline/Store/appsettings.json
+++ b/ContosoOnline/Store/appsettings.json
@@ -8,5 +8,5 @@
   },
   "AllowedHosts": "*",
   "PRODUCTS_URL": "http://localhost:5002",
-  "ORDERS_URL": "http://localhost:5000"
+  "ORDERS_URL": "http://localhost:5004"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     container_name: orders
     hostname: orders
     ports:
-      - 5000:8080
+      - 5004:8080
     build:
       context: .
       dockerfile: ./ContosoOnline/Orders/Dockerfile


### PR DESCRIPTION
The Mac AirPlay server runs on port 5000 in Montery and up which causes this application to fail to start.